### PR TITLE
Add unit tests for eam/alloy potential apis: chargeDensity, embedEnergy, and pairPotential

### DIFF
--- a/src/container/interpolation_object.h
+++ b/src/container/interpolation_object.h
@@ -31,9 +31,18 @@ public:
 
   /**
    * given a real value on x axis, find the corresponding spline and value p.
+   * @tparam X0_IS_ZERO true for the x0 is zero (data at x-axis is starting from zero).
+   * the @tparam X0_IS_ZERO can be considered as a special case.
+   * For example, in eam/fs, the embedding energies F(rho) always start from rho = 0.
+   * While for eam/he, it may not start from 0.
    */
-  inline SplineData findSpline(const double value) const {
-    double p = value * invDx + 1.0;
+  template <bool X0_IS_ZERO = false> inline SplineData findSpline(const double value) const {
+    double p = 0.0;
+    if (X0_IS_ZERO) {
+      p = value * invDx + 1.0;
+    } else {
+      p = (value - x0) * invDx + 1.0;
+    }
     int m = static_cast<int>(p);
     m = std::max(1, std::min(m, (n - 1)));
     p -= m;

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -16,6 +16,7 @@ set(TEST_SOURCE_FILES
         container/linear_array_test.cpp
         data_structure/array_map_test.cpp
         container/atom_type_lists_test.cpp
+        eam_alloy_pot_api_test.cpp
         interpolation_lists_sync_test.cpp
         )
 

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -7,6 +7,7 @@ configure_file(
 set(TEST_HEADER_FILES
         test_config.h
         eam_pot_fixture.hpp
+        eam_pot_linear_fixup.hpp
         )
 
 set(TEST_SOURCE_FILES

--- a/tests/unit/eam_alloy_pot_api_test.cpp
+++ b/tests/unit/eam_alloy_pot_api_test.cpp
@@ -28,3 +28,73 @@ TEST_F(EamPotAlloyLinearTestFixture, test_eam_alloy_embedded_calc) {
     EXPECT_DOUBLE_EQ(_pot->embedEnergy(key, 2.0 * max_rho / 3.0, max_rho), expected_embed(2.0 * max_rho / 3.0, key));
   }
 }
+
+TEST_F(EamPotAlloyLinearTestFixture, test_eam_alloy_elec_density_calc) {
+  // for key = 0
+  {
+    constexpr int key = 0;
+    const double max_x = max_x_for_elec_density(key);
+    EXPECT_DOUBLE_EQ(_pot->chargeDensity(key, (max_x / 5.0) * (max_x / 5.0)),
+                     expected_electron_density(max_x / 5.0, key));
+    EXPECT_DOUBLE_EQ(_pot->chargeDensity(key, (max_x / 16.0) * (max_x / 16.0)),
+                     expected_electron_density(max_x / 16.0, key));
+    EXPECT_DOUBLE_EQ(_pot->chargeDensity(key, (max_x / 32.0) * (max_x / 32.0)),
+                     expected_electron_density(max_x / 32.0, key));
+    EXPECT_DOUBLE_EQ(_pot->chargeDensity(key, (max_x / 2.0) * (max_x / 2.0)),
+                     expected_electron_density(max_x / 2.0, key));
+    EXPECT_DOUBLE_EQ(_pot->chargeDensity(key, (2.0 * max_x / 3.0 * (2.0 * max_x / 3.0))),
+                     expected_electron_density(2.0 * max_x / 3.0, key));
+  }
+
+  // for key = 2
+  {
+    constexpr int key = 2;
+    const double max_x = max_x_for_elec_density(key);
+    EXPECT_DOUBLE_EQ(_pot->chargeDensity(key, (max_x / 5.0) * (max_x / 5.0)),
+                     expected_electron_density(max_x / 5.0, key));
+    EXPECT_DOUBLE_EQ(_pot->chargeDensity(key, (max_x / 16.0) * (max_x / 16.0)),
+                     expected_electron_density(max_x / 16.0, key));
+    EXPECT_DOUBLE_EQ(_pot->chargeDensity(key, (max_x / 32.0) * (max_x / 32.0)),
+                     expected_electron_density(max_x / 32.0, key));
+    EXPECT_DOUBLE_EQ(_pot->chargeDensity(key, (max_x / 2.0) * (max_x / 2.0)),
+                     expected_electron_density(max_x / 2.0, key));
+    EXPECT_DOUBLE_EQ(_pot->chargeDensity(key, (2.0 * max_x / 3.0 * (2.0 * max_x / 3.0))),
+                     expected_electron_density(2.0 * max_x / 3.0, key));
+  }
+}
+
+TEST_F(EamPotAlloyLinearTestFixture, test_eam_alloy_pair_phi_calc) {
+  // for key1 = 0, key2 = 0
+  {
+    constexpr int key1 = 0;
+    constexpr int key2 = 0;
+    const double max_x = max_x_for_pair_phi(key1, key2);
+    EXPECT_DOUBLE_EQ(_pot->pairPotential(key1, key2, (max_x / 5.0) * (max_x / 5.0)),
+                     expected_phi(max_x / 5.0, key1, key2));
+    EXPECT_DOUBLE_EQ(_pot->pairPotential(key1, key2, (max_x / 16.0) * (max_x / 16.0)),
+                     expected_phi(max_x / 16.0, key1, key2));
+    EXPECT_DOUBLE_EQ(_pot->pairPotential(key1, key2, (max_x / 32.0) * (max_x / 32.0)),
+                     expected_phi(max_x / 32.0, key1, key2));
+    EXPECT_DOUBLE_EQ(_pot->pairPotential(key1, key2, (max_x / 2.0) * (max_x / 2.0)),
+                     expected_phi(max_x / 2.0, key1, key2));
+    EXPECT_DOUBLE_EQ(_pot->pairPotential(key1, key2, (2.0 * max_x / 3.0 * (2.0 * max_x / 3.0))),
+                     expected_phi(2.0 * max_x / 3.0, key1, key2));
+  }
+
+  // for key1 = 1, key2 = 2
+  {
+    constexpr int key1 = 1;
+    constexpr int key2 = 2;
+    const double max_x = max_x_for_pair_phi(key1, key2);
+    EXPECT_DOUBLE_EQ(_pot->pairPotential(key1, key2, (max_x / 5.0) * (max_x / 5.0)),
+                     expected_phi(max_x / 5.0, key1, key2));
+    EXPECT_DOUBLE_EQ(_pot->pairPotential(key1, key2, (max_x / 16.0) * (max_x / 16.0)),
+                     expected_phi(max_x / 16.0, key1, key2));
+    EXPECT_DOUBLE_EQ(_pot->pairPotential(key1, key2, (max_x / 32.0) * (max_x / 32.0)),
+                     expected_phi(max_x / 32.0, key1, key2));
+    EXPECT_DOUBLE_EQ(_pot->pairPotential(key1, key2, (max_x / 2.0) * (max_x / 2.0)),
+                     expected_phi(max_x / 2.0, key1, key2));
+    EXPECT_DOUBLE_EQ(_pot->pairPotential(key1, key2, (2.0 * max_x / 3.0 * (2.0 * max_x / 3.0))),
+                     expected_phi(2.0 * max_x / 3.0, key1, key2));
+  }
+}

--- a/tests/unit/eam_alloy_pot_api_test.cpp
+++ b/tests/unit/eam_alloy_pot_api_test.cpp
@@ -1,0 +1,30 @@
+//
+// Created by genshen on 2023-5-11.
+//
+
+#include "eam_pot_linear_fixup.hpp"
+#include <gtest/gtest.h>
+
+TEST_F(EamPotAlloyLinearTestFixture, test_eam_alloy_embedded_calc) {
+  // for key = 0
+  {
+    constexpr int key = 0;
+    const double max_rho = max_rho_for_embedded(key);
+    EXPECT_EQ(_pot->embedEnergy(key, max_rho / 5.0, max_rho), expected_embed(max_rho / 5.0, key));
+    EXPECT_EQ(_pot->embedEnergy(key, max_rho / 16.0, max_rho), expected_embed(max_rho / 16.0, key));
+    EXPECT_EQ(_pot->embedEnergy(key, max_rho / 32.0, max_rho), expected_embed(max_rho / 32.0, key));
+    EXPECT_EQ(_pot->embedEnergy(key, max_rho / 2.0, max_rho), expected_embed(max_rho / 2.0, key));
+    EXPECT_DOUBLE_EQ(_pot->embedEnergy(key, 2.0 * max_rho / 3.0, max_rho), expected_embed(2.0 * max_rho / 3.0, key));
+  }
+
+  // for key = 2
+  {
+    constexpr int key = 2;
+    const double max_rho = max_rho_for_embedded(key);
+    EXPECT_EQ(_pot->embedEnergy(key, max_rho / 5.0, max_rho), expected_embed(max_rho / 5.0, key));
+    EXPECT_EQ(_pot->embedEnergy(key, max_rho / 16.0, max_rho), expected_embed(max_rho / 16.0, key));
+    EXPECT_EQ(_pot->embedEnergy(key, max_rho / 32.0, max_rho), expected_embed(max_rho / 32.0, key));
+    EXPECT_EQ(_pot->embedEnergy(key, max_rho / 2.0, max_rho), expected_embed(max_rho / 2.0, key));
+    EXPECT_DOUBLE_EQ(_pot->embedEnergy(key, 2.0 * max_rho / 3.0, max_rho), expected_embed(2.0 * max_rho / 3.0, key));
+  }
+}

--- a/tests/unit/eam_pot_linear_fixup.hpp
+++ b/tests/unit/eam_pot_linear_fixup.hpp
@@ -53,7 +53,7 @@ public:
     for (i = 0; i < ELE_SIZE; i++) {
       double data_buff[5000] = {};
       for (int k = 0; k < 5000; k++) {
-        data_buff[k] = gen_phi(i, k);
+        data_buff[k] = gen_phi(i, 0, k);
       }
       for (j = 0; j <= i; j++) {
         const double x0 = i * ELE_SIZE + j;
@@ -68,9 +68,12 @@ public:
 
   static inline double gen_electron_density(int k) { return (k * DELTA * 3.0); }
   static inline double gen_embed(int k) { return (-k * DELTA * 10.0); }
-  static inline double gen_phi(int key1, int k) { return (key1 + k * DELTA * 10.0); }
+  static inline double gen_phi(int key1, int key2, int k) { return (key1 + k * DELTA * 10.0); }
 
   inline double max_rho_for_embedded(int key) { return -key + 0.001 * DATA_SIZE; }
+  inline double max_x_for_elec_density(int key) { return key + 0.001 * DATA_SIZE; }
+  inline double max_x_for_pair_phi(int key1, int key2) { return key1 * ELE_SIZE + key2 + 0.001 * DATA_SIZE; }
+
   /**
    * the expected value for electron_density at a given distance and key.
    */
@@ -92,9 +95,10 @@ public:
     if (key1 < key2) {
       std::swap(key1, key2);
     }
-    int index = key1 * ELE_SIZE + key2;
+    int index = key1 * (key1 + 1) / 2 + key2;
     const double x0 = x0_eam_phi[index];
-    return (key1 + (r - x0) / 0.001) * DELTA * 10.0; // keep the same as expected_phi
+    const double e = (key1 + (r - x0) / 0.001) * DELTA * 10.0; // keep the same as expected_phi
+    return e / r;
   }
 
   void TearDown() override {

--- a/tests/unit/eam_pot_linear_fixup.hpp
+++ b/tests/unit/eam_pot_linear_fixup.hpp
@@ -1,0 +1,112 @@
+//
+// Created by genshen on 2023-5-11.
+//
+
+#ifndef POTENTIAL_GTEST_EAM_POT_LINEAR_FIXUP_H
+#define POTENTIAL_GTEST_EAM_POT_LINEAR_FIXUP_H
+
+#include <eam.h>
+#include <gtest/gtest.h>
+#include <random>
+
+/**
+ * EamPotAlloyLinearTestFixture create a linear potential table and provide interpolation for it.
+ * In the linear potential table, it will be very easy to check the expected value for each potential category.
+ */
+class EamPotAlloyLinearTestFixture : public ::testing::Test {
+public:
+  eam *_pot = nullptr;
+  atom_type::_type_prop_key *prop_key_list = nullptr;
+
+  constexpr static unsigned int ELE_SIZE = 3;
+  constexpr static unsigned int DATA_SIZE = 5000;
+  //  constexpr static unsigned int RAND_SEED = 27321;
+  constexpr static double DELTA = 0.1;
+
+  void SetUp() override {
+    const unsigned int root_rank = 0;
+    int own_rank = 0;
+    MPI_Comm_rank(MPI_COMM_WORLD, &own_rank);
+
+    _pot = eam::newInstance(EAM_STYLE_ALLOY, ELE_SIZE, root_rank, own_rank, MPI_COMM_WORLD);
+    prop_key_list = new atom_type::_type_prop_key[ELE_SIZE];
+
+    // data buffer
+    double data_buff_emb[5000] = {};
+    double data_buff_elec[5000] = {};
+    for (int k = 0; k < 5000; k++) {
+      data_buff_emb[k] = gen_embed(k);
+      data_buff_elec[k] = gen_electron_density(k);
+    }
+
+    auto eam_alloy_loader = dynamic_cast<EamAlloyLoader *>(_pot->eam_pot_loader);
+    for (int i = 0; i < ELE_SIZE; i++) {
+      const int key = i; // key is atom number
+      prop_key_list[i] = key;
+      x0_electron_density.push_back(key);
+      x0_embedded.push_back(-key);
+      eam_alloy_loader->embedded.append(key, DATA_SIZE, -key, 0.001, data_buff_emb);
+      eam_alloy_loader->electron_density.append(key, DATA_SIZE, key, 0.001, data_buff_elec);
+    }
+
+    int i, j;
+    for (i = 0; i < ELE_SIZE; i++) {
+      double data_buff[5000] = {};
+      for (int k = 0; k < 5000; k++) {
+        data_buff[k] = gen_phi(i, k);
+      }
+      for (j = 0; j <= i; j++) {
+        const double x0 = i * ELE_SIZE + j;
+        x0_eam_phi.push_back(x0);
+        eam_alloy_loader->eam_phi.append(prop_key_list[i], prop_key_list[j], DATA_SIZE, x0, 0.001, data_buff);
+      }
+    }
+
+    _pot->eamBCast(root_rank, own_rank, MPI_COMM_WORLD);
+    _pot->interpolateFile(); // interpolation
+  }
+
+  static inline double gen_electron_density(int k) { return (k * DELTA * 3.0); }
+  static inline double gen_embed(int k) { return (-k * DELTA * 10.0); }
+  static inline double gen_phi(int key1, int k) { return (key1 + k * DELTA * 10.0); }
+
+  inline double max_rho_for_embedded(int key) { return -key + 0.001 * DATA_SIZE; }
+  /**
+   * the expected value for electron_density at a given distance and key.
+   */
+  inline double expected_electron_density(const double r, const int key) {
+    const double x0 = x0_electron_density[key];
+    return ((r - x0) / 0.001) * DELTA * 3.0;
+  }
+  /**
+   * the expected value for embedded at a given electron density and key.
+   */
+  inline double expected_embed(const double rho, const int key) {
+    const double x0 = x0_embedded[key];
+    return (-(rho - x0) / 0.001) * DELTA * 10.0; // keep the same as gen_embed
+  }
+  /**
+   * the expected value for pair potential at a given distance and two keys.
+   */
+  inline double expected_phi(const double r, int key1, int key2) {
+    if (key1 < key2) {
+      std::swap(key1, key2);
+    }
+    int index = key1 * ELE_SIZE + key2;
+    const double x0 = x0_eam_phi[index];
+    return (key1 + (r - x0) / 0.001) * DELTA * 10.0; // keep the same as expected_phi
+  }
+
+  void TearDown() override {
+    delete _pot;
+    delete[] prop_key_list;
+  }
+
+protected:
+  std::vector<double> x0_embedded;         // list of x0 of embedded potential table.
+  std::vector<double> x0_electron_density; // list of x0 of electron density potential table.
+  std::vector<double> x0_eam_phi;          // list of x0 of eam_phi potential table.
+};
+
+
+#endif // POTENTIAL_GTEST_EAM_POT_LINEAR_FIXUP_H


### PR DESCRIPTION
- we generate a linear potential table for eam/alloy for better eam potential calculation.
- we add unit tests for the three eam api (only tested for eam/alloy style now).
