### PR TITLE
feat(eam): add api `eam::embedEnergy` without `max_rho` parameter: auto-detect max_rho from table

### DIFF
--- a/src/eam.cpp
+++ b/src/eam.cpp
@@ -94,8 +94,17 @@ double eam::dEmbedEnergy(const atom_type::_type_prop_key _atom_key, const double
   return (s.spline[0] * s.p + s.spline[1]) * s.p + s.spline[2];
 }
 
+double eam::embedEnergy(const atom_type::_type_prop_key _atom_key, const double rho) {
+  const InterpolationObject *embed = eam_pot_loader->loadEmbedded(_atom_key);
+  return embedEnergyImp(embed, rho, embed->max_val);
+}
+
 double eam::embedEnergy(const atom_type::_type_prop_key _atom_key, const double rho, const double max_rho) {
   const InterpolationObject *embed = eam_pot_loader->loadEmbedded(_atom_key);
+  return embedEnergyImp(embed, rho, max_rho);
+}
+
+double eam::embedEnergyImp(const InterpolationObject *embed, const double rho, const double max_rho) {
   const SplineData s = embed->findSpline(rho);
   double phi = ((s.spline[3] * s.p + s.spline[4]) * s.p + s.spline[5]) * s.p + s.spline[6];
   if (rho > max_rho) {

--- a/src/eam.h
+++ b/src/eam.h
@@ -112,6 +112,8 @@ public:
    */
   double embedEnergy(const atom_type::_type_prop_key _atom_key, const double rho, const double max_rho);
 
+  double embedEnergy(const atom_type::_type_prop_key _atom_key, const double rho);
+
   /**
    * pair potential energy.
    * @return pair potential energy.
@@ -143,6 +145,8 @@ private:
       return nullptr;
     }
   }
+
+  static double embedEnergyImp(const InterpolationObject *embed, const double rho, const double max_rho);
 
 public:
   /**


### PR DESCRIPTION

We now provide two `eam::embedEnergy` apis, one with `max_rho` parameter (user can pass the user-specified max value of rho(charge density) to it); another one without `max_rho` parameter (the api itself can auto-detect the max value of rho from potential table).