### PR TITLE
Add unit tests for eam/fs potential apis: chargeDensity, embedEnergy, and pairPotential

### DIFF
--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -18,6 +18,7 @@ set(TEST_SOURCE_FILES
         container/atom_type_lists_test.cpp
         eam_alloy_pot_api_test.cpp
         interpolation_lists_sync_test.cpp
+        eam_fs_pot_api_test.cpp
         )
 
 # set binary path and lib storage path wile compiling process.

--- a/tests/unit/eam_fs_pot_api_test.cpp
+++ b/tests/unit/eam_fs_pot_api_test.cpp
@@ -1,0 +1,103 @@
+//
+// Created by genshen on 2023/7/10.
+//
+
+#include "eam_pot_linear_fixup.hpp"
+#include <gtest/gtest.h>
+
+TEST_F(EamPotFsLinearTestFixture, test_eam_fs_embedded_calc) {
+  // for key = 0
+  {
+    constexpr int key = 0;
+    const double max_rho = max_rho_for_embedded(key);
+    EXPECT_EQ(_pot->embedEnergy(key, max_rho / 5.0, max_rho), expected_embed(max_rho / 5.0, key));
+    EXPECT_EQ(_pot->embedEnergy(key, max_rho / 16.0, max_rho), expected_embed(max_rho / 16.0, key));
+    EXPECT_EQ(_pot->embedEnergy(key, max_rho / 32.0, max_rho), expected_embed(max_rho / 32.0, key));
+    EXPECT_EQ(_pot->embedEnergy(key, max_rho / 2.0, max_rho), expected_embed(max_rho / 2.0, key));
+    EXPECT_DOUBLE_EQ(_pot->embedEnergy(key, 2.0 * max_rho / 3.0, max_rho), expected_embed(2.0 * max_rho / 3.0, key));
+  }
+
+  // for key = 2
+  {
+    constexpr int key = 2;
+    const double max_rho = max_rho_for_embedded(key);
+    EXPECT_EQ(_pot->embedEnergy(key, max_rho / 5.0, max_rho), expected_embed(max_rho / 5.0, key));
+    EXPECT_EQ(_pot->embedEnergy(key, max_rho / 16.0, max_rho), expected_embed(max_rho / 16.0, key));
+    EXPECT_EQ(_pot->embedEnergy(key, max_rho / 32.0, max_rho), expected_embed(max_rho / 32.0, key));
+    EXPECT_EQ(_pot->embedEnergy(key, max_rho / 2.0, max_rho), expected_embed(max_rho / 2.0, key));
+    EXPECT_DOUBLE_EQ(_pot->embedEnergy(key, 2.0 * max_rho / 3.0, max_rho), expected_embed(2.0 * max_rho / 3.0, key));
+  }
+}
+
+TEST_F(EamPotFsLinearTestFixture, test_eam_fs_elec_density_calc) {
+  // for key = (0, 0)
+  {
+    constexpr int key1 = 0;
+    constexpr int key2 = 0;
+    const double max_x = max_x_for_elec_density(key1, key2);
+    EXPECT_DOUBLE_EQ(_pot->chargeDensity(key2, key1, (max_x / 5.0) * (max_x / 5.0)),
+                     expected_electron_density(max_x / 5.0, key1, key2));
+    EXPECT_DOUBLE_EQ(_pot->chargeDensity(key2, key1, (max_x / 16.0) * (max_x / 16.0)),
+                     expected_electron_density(max_x / 16.0, key1, key2));
+    EXPECT_DOUBLE_EQ(_pot->chargeDensity(key2, key1, (max_x / 32.0) * (max_x / 32.0)),
+                     expected_electron_density(max_x / 32.0, key1, key2));
+    EXPECT_DOUBLE_EQ(_pot->chargeDensity(key2, key1, (max_x / 2.0) * (max_x / 2.0)),
+                     expected_electron_density(max_x / 2.0, key1, key2));
+    EXPECT_DOUBLE_EQ(_pot->chargeDensity(key2, key1, (2.0 * max_x / 3.0) * (2.0 * max_x / 3.0)),
+                     expected_electron_density(2.0 * max_x / 3.0, key1, key2));
+  }
+
+  // for key = (2, 1)
+  {
+    constexpr int key1 = 2;
+    constexpr int key2 = 1;
+    const double max_x = max_x_for_elec_density(key1, key2);
+    constexpr double base = key1 * ELE_SIZE + key2;
+    EXPECT_DOUBLE_EQ(_pot->chargeDensity(key2, key1, (base + max_x / 5.0) * (base + max_x / 5.0)),
+                     expected_electron_density(base + max_x / 5.0, key1, key2));
+    EXPECT_DOUBLE_EQ(_pot->chargeDensity(key2, key1, (max_x / 16.0) * (max_x / 16.0)),
+                     expected_electron_density(max_x / 16.0, key1, key2));
+    EXPECT_DOUBLE_EQ(_pot->chargeDensity(key2, key1, (max_x / 32.0) * (max_x / 32.0)),
+                     expected_electron_density(max_x / 32.0, key1, key2));
+    EXPECT_DOUBLE_EQ(_pot->chargeDensity(key2, key1, (max_x / 2.0) * (max_x / 2.0)),
+                     expected_electron_density(max_x / 2.0, key1, key2));
+    EXPECT_DOUBLE_EQ(_pot->chargeDensity(key2, key1, (2.0 * max_x / 3.0) * (2.0 * max_x / 3.0)),
+                     expected_electron_density(2.0 * max_x / 3.0, key1, key2));
+  }
+}
+
+TEST_F(EamPotFsLinearTestFixture, test_eam_fs_pair_phi_calc) {
+  // for key1 = 0, key2 = 0
+  {
+    constexpr int key1 = 0;
+    constexpr int key2 = 0;
+    const double max_x = max_x_for_pair_phi(key1, key2);
+    EXPECT_DOUBLE_EQ(_pot->pairPotential(key1, key2, (max_x / 5.0) * (max_x / 5.0)),
+                     expected_phi(max_x / 5.0, key1, key2));
+    EXPECT_DOUBLE_EQ(_pot->pairPotential(key1, key2, (max_x / 16.0) * (max_x / 16.0)),
+                     expected_phi(max_x / 16.0, key1, key2));
+    EXPECT_DOUBLE_EQ(_pot->pairPotential(key1, key2, (max_x / 32.0) * (max_x / 32.0)),
+                     expected_phi(max_x / 32.0, key1, key2));
+    EXPECT_DOUBLE_EQ(_pot->pairPotential(key1, key2, (max_x / 2.0) * (max_x / 2.0)),
+                     expected_phi(max_x / 2.0, key1, key2));
+    EXPECT_DOUBLE_EQ(_pot->pairPotential(key1, key2, (2.0 * max_x / 3.0) * (2.0 * max_x / 3.0)),
+                     expected_phi(2.0 * max_x / 3.0, key1, key2));
+  }
+
+  // for key1 = 1, key2 = 2
+  {
+    constexpr int key1 = 1;
+    constexpr int key2 = 2;
+    const double max_x = max_x_for_pair_phi(key1, key2);
+    EXPECT_DOUBLE_EQ(_pot->pairPotential(key1, key2, (max_x / 5.0) * (max_x / 5.0)),
+                     expected_phi(max_x / 5.0, key1, key2));
+    EXPECT_DOUBLE_EQ(_pot->pairPotential(key1, key2, (max_x / 16.0) * (max_x / 16.0)),
+                     expected_phi(max_x / 16.0, key1, key2));
+    EXPECT_DOUBLE_EQ(_pot->pairPotential(key1, key2, (max_x / 32.0) * (max_x / 32.0)),
+                     expected_phi(max_x / 32.0, key1, key2));
+    EXPECT_DOUBLE_EQ(_pot->pairPotential(key1, key2, (max_x / 2.0) * (max_x / 2.0)),
+                     expected_phi(max_x / 2.0, key1, key2));
+    EXPECT_DOUBLE_EQ(_pot->pairPotential(key1, key2, (2.0 * max_x / 3.0) * (2.0 * max_x / 3.0)),
+                     expected_phi(2.0 * max_x / 3.0, key1, key2));
+  }
+}

--- a/tests/unit/eam_pot_linear_fixup.hpp
+++ b/tests/unit/eam_pot_linear_fixup.hpp
@@ -112,5 +112,117 @@ protected:
   std::vector<double> x0_eam_phi;          // list of x0 of eam_phi potential table.
 };
 
+// similar to EamPotAlloyLinearTestFixture, but it is for eam/fs.
+class EamPotFsLinearTestFixture : public ::testing::Test {
+public:
+  eam *_pot = nullptr;
+  atom_type::_type_prop_key *prop_key_list = nullptr;
+
+  constexpr static unsigned int ELE_SIZE = 3;
+  constexpr static unsigned int DATA_SIZE = 5000;
+  constexpr static unsigned int RAND_SEED = 27324;
+  constexpr static double DELTA = 0.125;
+
+  void SetUp() override {
+    const unsigned int root_rank = 0;
+    int own_rank = 0;
+    MPI_Comm_rank(MPI_COMM_WORLD, &own_rank);
+
+    _pot = eam::newInstance(EAM_STYLE_FS, ELE_SIZE, root_rank, own_rank, MPI_COMM_WORLD);
+    prop_key_list = new atom_type::_type_prop_key[ELE_SIZE];
+
+    std::uniform_real_distribution<double> dist_f(0.0, 5.0);
+
+    // data buffer
+    double data_buff_emb[5000] = {};
+    for (int k = 0; k < 5000; k++) {
+      data_buff_emb[k] = gen_embed(k);
+    }
+
+    auto eam_fs_loader = dynamic_cast<EamFsLoader *>(_pot->eam_pot_loader);
+    for (int i = 0; i < ELE_SIZE; i++) {
+      const int key = i; // key is atom number
+      prop_key_list[i] = key;
+      x0_embedded.push_back(key);
+      eam_fs_loader->embedded.append(key, DATA_SIZE, key, 0.001, data_buff_emb);
+      // add electron density potential
+      double data_buff_elec[5000] = {};
+      for (int k = 0; k < 5000; k++) {
+        data_buff_elec[k] = gen_electron_density(i, k);
+      }
+      for (int j = 0; j < ELE_SIZE; j++) {
+        const double x0_ele = i * ELE_SIZE + j;
+        x0_electron_density.push_back(x0_ele);
+        eam_fs_loader->electron_density.append(key, DATA_SIZE, x0_ele, 0.001, data_buff_elec);
+      }
+    }
+
+    int i, j;
+    for (i = 0; i < ELE_SIZE; i++) {
+      for (j = 0; j <= i; j++) {
+        // generate table for phi
+        double data_buff[5000] = {};
+        for (int k = 0; k < 5000; k++) {
+          data_buff[k] = gen_phi(i, j, k); // note: key1(j) >= key2(i)
+        }
+        const double x0 = i * ELE_SIZE + j;
+        x0_eam_phi.push_back(x0);
+        eam_fs_loader->eam_phi.append(prop_key_list[i], prop_key_list[j], DATA_SIZE, x0, 0.001, data_buff);
+      }
+    }
+
+    _pot->eamBCast(root_rank, own_rank, MPI_COMM_WORLD);
+    _pot->interpolateFile(); // interpolation
+  }
+
+  static inline double gen_electron_density(int key1, int k) { return (k * DELTA * 3.0 - key1 * 1.0); }
+  static inline double gen_embed(int k) { return (-k * DELTA * 10.0); }
+  static inline double gen_phi(int key1, int key2, int k) { return (key1 * ELE_SIZE + key2 + k * DELTA * 10.0); }
+
+  static inline double max_rho_for_embedded(int key) { return key + 0.001 * DATA_SIZE; }
+  static inline double max_x_for_elec_density(int key1, int key2) {
+    return (key1 * ELE_SIZE + key2) + 0.001 * DATA_SIZE;
+  }
+  static inline double max_x_for_pair_phi(int key1, int key2) { return key1 * ELE_SIZE + key2 + 0.001 * DATA_SIZE; }
+
+  /**
+   * the expected value for electron_density at a given distance and key.
+   */
+  inline double expected_electron_density(const double r, const int key1, const int key2) {
+    const double x0 = x0_electron_density[key1 * ELE_SIZE + key2];
+    return ((r - x0) / 0.001) * DELTA * 3.0 - (key1 * 1.0);
+  }
+
+  /**
+   * the expected value for embedded at a given electron density and key.
+   */
+  inline double expected_embed(const double rho, const int key) {
+    const double x0 = x0_embedded[key];
+    return (-(rho - x0) / 0.001) * DELTA * 10.0; // keep the same as gen_embed
+  }
+
+  /**
+   * the expected value for pair potential at a given distance and two keys.
+   */
+  inline double expected_phi(const double r, int key1, int key2) {
+    if (key1 < key2) {
+      std::swap(key1, key2);
+    }
+    int index = key1 * (key1 + 1) / 2 + key2;
+    const double x0 = x0_eam_phi[index];
+    const double e = (key1 * ELE_SIZE + key2) + ((r - x0) / 0.001) * DELTA * 10.0; // keep the same as expected_phi
+    return e / r;
+  }
+
+  void TearDown() override {
+    delete _pot;
+    delete[] prop_key_list;
+  }
+
+protected:
+  std::vector<double> x0_embedded;         // list of x0 of embedded potential table.
+  std::vector<double> x0_electron_density; // list of x0 of electron density potential table.
+  std::vector<double> x0_eam_phi;          // list of x0 of eam_phi potential table.
+};
 
 #endif // POTENTIAL_GTEST_EAM_POT_LINEAR_FIXUP_H


### PR DESCRIPTION
Add eam/fs potential api tests.

In this commit, we add: 1) linear potential table generation fixup for eam/fs potential; 2) unit tests for api `chargeDensity`, `embedEnergy` and `pairPotential` under eam/fs type potential.