### PR TITLE
Feature&Test: replace `FILE*` by iostream in potential parser api and add parser tests.

### DIFF
--- a/src/parser/eam_base_parser.hpp
+++ b/src/parser/eam_base_parser.hpp
@@ -6,6 +6,7 @@
 #define POT_EAM_BASE_PARSER_HPP
 
 #include <cstring>
+#include <iostream>
 #include <stdlib.h>
 
 #include "parser.h"
@@ -13,7 +14,7 @@
 class EamBaseParse : public Parser {
 
 public:
-  explicit EamBaseParse(const std::string &filename) : Parser(filename) {}
+  explicit EamBaseParse(std::istream &pot_file) : Parser(pot_file) {}
 
 protected:
   template <typename T> static void grab(FILE *fptr, int n, T *list) {
@@ -23,6 +24,21 @@ protected:
     int i = 0;
     while (i < n) {
       fgets(line, 1024, fptr);
+      ptr = strtok(line, " \t\n\r\f");
+      list[i++] = atof(ptr);
+      while ((ptr = strtok(nullptr, " \t\n\r\f"))) {
+        list[i++] = atof(ptr);
+      }
+    }
+  }
+
+  template <typename T> static void grab(std::istream &pot_file, int n, T *list) {
+    char *ptr;
+    char line[1024];
+
+    int i = 0;
+    while (i < n) {
+      pot_file.getline(&line[0], sizeof(line));
       ptr = strtok(line, " \t\n\r\f");
       list[i++] = atof(ptr);
       while ((ptr = strtok(nullptr, " \t\n\r\f"))) {

--- a/src/parser/funcfl_parser.cpp
+++ b/src/parser/funcfl_parser.cpp
@@ -5,12 +5,12 @@
 #include "funcfl_parser.h"
 #include <utils.h>
 
-FuncflParser::FuncflParser(const std::string filename) : Parser(filename) {}
+FuncflParser::FuncflParser(std::istream &pot_file) : Parser(pot_file) {}
 
 void FuncflParser::parseHeader() {
   // the 1st line of the file
   char tmp[4096];
-  fgets(tmp, sizeof(tmp), pot_file);
+  pot_file.getline(tmp, sizeof(tmp));
   char name[3];
   sscanf(tmp, "%s", name);
 
@@ -18,15 +18,13 @@ void FuncflParser::parseHeader() {
   atom_type::_type_atomic_no nAtomic;
   double mass, lat;
   char latticeType[8];
-  fgets(tmp, sizeof(tmp), pot_file);
+  pot_file.getline(tmp, sizeof(tmp));
   sscanf(tmp, "%hu %le %le %s", &nAtomic, &mass, &lat, latticeType);
 
   // todo eam_instance->setlatticeType(latticeType); // lattice type
 
   // the 3rd line of the file
-  int nRho, nR;
-  double dRho, dR, cutoff;
-  fgets(tmp, sizeof(tmp), pot_file);
+  pot_file.getline(tmp, sizeof(tmp));
   sscanf(tmp, "%d %le %d %le %le", &nRho, &dRho, &nR, &dR, &cutoff);
   type_lists.addAtomProp(nAtomic, "", mass, lat, cutoff);
 }
@@ -38,13 +36,13 @@ void FuncflParser::parseBody(eam *eam_instance) {
 
   // read embedded energy table
   for (int ii = 0; ii < nRho; ++ii) {
-    fscanf(pot_file, "%lg", buf + ii);
+    pot_file >> buf[ii];
   }
   //   fixme eam_instance->initf(0, nRho, x0, dRho, buf); //通过读取势文件的数据建立table
 
   // read pair potnetial table
   for (int ii = 0; ii < nR; ++ii) {
-    fscanf(pot_file, "%lg", buf + ii);
+    pot_file >> buf[ii];
   }
   double r;
   for (int ii = 1; ii < nR; ++ii) {
@@ -57,7 +55,7 @@ void FuncflParser::parseBody(eam *eam_instance) {
 
   // read electron density table
   for (int ii = 0; ii < nR; ++ii) {
-    fscanf(pot_file, "%lg", buf + ii);
+    pot_file >> buf[ii];
   }
   //  fixme  eam_instance->initrho(0, nR, x0, dR, buf);
 

--- a/src/parser/funcfl_parser.h
+++ b/src/parser/funcfl_parser.h
@@ -8,17 +8,20 @@
 
 #include "parser.h"
 
+/**
+ * @deprecated FuncflParser is not maintained any more.
+ */
 class FuncflParser : public Parser {
 public:
-  explicit FuncflParser(const std::string filename);
+  explicit FuncflParser(std::istream &pot_file);
 
   void parseHeader() override;
 
   void parseBody(eam *eam_instance) override;
 
 private:
-  int nRho, nR;                     // at line 3 in header.
-  double /*dRho, */ dR /*,cutoff*/; // at line 3 in header
+  int nRho, nR;            // at line 3 in header.
+  double dRho, dR, cutoff; // at line 3 in header
 };
 
 #endif // POT_FUNL_PARSER_H

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -7,17 +7,7 @@
 #include <cstring>
 #include <string>
 
-Parser::Parser(const std::string filename)
-    : file_ele_size(0), filter_ele_size(0), filter_ele_types(), pot_filename(filename) {
-  char tmp[4096];
-  snprintf(tmp, pot_filename.size() + 1, "%s", pot_filename.c_str());
-
-  pot_file = fopen(tmp, "r");
-  if (pot_file == nullptr) {
-    printf("error, open file %s failed.\n", pot_filename.c_str());
-    return; // todo error
-  }
-}
+Parser::Parser(std::istream &pot_file) : file_ele_size(0), filter_ele_size(0), filter_ele_types(), pot_file(pot_file) {}
 
 void Parser::setFilterEleTypes(const std::vector<atom_type::_type_prop_key> ele_types) {
   filter_ele_types = ele_types;
@@ -35,7 +25,7 @@ bool Parser::isInFilterList(atom_type::_type_prop_key key) {
   return false;
 }
 
-void Parser::done() { fclose(pot_file); }
+//void Parser::done() { pot_file; }
 
 atom_type::_type_atom_types Parser::getEles() const {
   if (isEleTypesFilterEnabled()) {

--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -8,6 +8,8 @@
 #include "container/atom_type_lists.h"
 #include "eam.h"
 #include "types.h"
+
+#include <iostream>
 #include <string>
 
 /**
@@ -18,7 +20,7 @@ public:
   // all types are saved in this object while parsing.
   AtomPropsList type_lists;
 
-  explicit Parser(const std::string filename);
+  explicit Parser(std::istream &pot_file);
 
   /**
    * When parsing potential file, we only consider the element types in @param ele_types.
@@ -44,7 +46,7 @@ public:
    */
   virtual void parseBody(eam *eam_instance) = 0;
 
-  virtual void done();
+  //  virtual void done();
 
   // get the real elements count.
   atom_type::_type_atom_types getEles() const;
@@ -55,7 +57,8 @@ protected:
   // the size/count of element after filtering.
   atom_type::_type_atom_types filter_ele_size;
   std::vector<atom_type::_type_prop_key> filter_ele_types;
-  FILE *pot_file;
+
+  std::istream &pot_file;
 
   /**
    * check whether an element type is in the filtering list.

--- a/src/parser/setfl_parser.cpp
+++ b/src/parser/setfl_parser.cpp
@@ -8,17 +8,18 @@
 #include <cstdlib>
 #include <cstring>
 
-SetflParser::SetflParser(const std::string &filename) : EamBaseParse(filename) {}
+SetflParser::SetflParser(std::istream &pot_file) : EamBaseParse(pot_file) {}
 
 void SetflParser::parseHeader() {
   char tmp[4096];
   // file comments in the first 3 lines of the file.
-  fgets(tmp, sizeof(tmp), pot_file);
-  fgets(tmp, sizeof(tmp), pot_file);
-  fgets(tmp, sizeof(tmp), pot_file);
+  std::string str_tmp;
+  std::getline(pot_file, str_tmp);
+  std::getline(pot_file, str_tmp);
+  std::getline(pot_file, str_tmp);
 
   // line 4 in file
-  fgets(tmp, sizeof(tmp), pot_file);
+  pot_file.getline(&tmp[0], sizeof(tmp));
   sscanf(tmp, "%hu", &file_ele_size); // number of atom types
 
 
@@ -54,7 +55,7 @@ void SetflParser::parseHeader() {
   delete[] words;
   // line 5 in file
   // all types of atom use the same cutoff.
-  fgets(tmp, sizeof(tmp), pot_file);
+  pot_file.getline(&tmp[0], sizeof(tmp));
   sscanf(tmp, "%d %le %d %le %le", &header.nRho, &header.dRho, &header.nR, &header.dR, &header.cutoff);
 }
 
@@ -69,7 +70,6 @@ void SetflParser::parseBody(eam *eam_instance) {
 }
 
 void SetflParser::parseBodyEamAlloy(EamAlloyLoader *pot_loader) {
-
   char tmp[4096];
   const int bufSize = std::max(header.nRho, header.nR);
   double *buf = new double[bufSize];
@@ -78,7 +78,7 @@ void SetflParser::parseBodyEamAlloy(EamAlloyLoader *pot_loader) {
 
   // for each type of atom
   for (int i = 0; i < file_ele_size; i++) {
-    fgets(tmp, sizeof(tmp), pot_file);
+    pot_file.getline(&tmp[0], sizeof(tmp));
     atom_type::_type_atomic_no nAtomic;
     double mass, lat;    // mass, lattice const
     char latticeType[8]; // lattice type.
@@ -125,7 +125,7 @@ void SetflParser::parseBodyEamFs(EamFsLoader *pot_loader) {
   atom_type::_type_prop_key *prop_key_list = new atom_type::_type_prop_key[file_ele_size];
 
   for (int i = 0; i < file_ele_size; i++) {
-    fgets(tmp, sizeof(tmp), pot_file);
+    pot_file.getline(&tmp[0], sizeof(tmp));
     atom_type::_type_atomic_no nAtomic;
     double mass, lat;    // mass, lattice const
     char latticeType[8]; // lattice type.

--- a/src/parser/setfl_parser.h
+++ b/src/parser/setfl_parser.h
@@ -6,6 +6,8 @@
 #ifndef POT_SETFL_PARSER_H
 #define POT_SETFL_PARSER_H
 
+#include <iostream>
+
 #include "eam_base_parser.hpp"
 #include "parser.h"
 
@@ -17,7 +19,7 @@ struct EamPotFileHeader {
 // parser for parsing potential file of "setdl" format.
 class SetflParser : public EamBaseParse {
 public:
-  explicit SetflParser(const std::string &filename);
+  explicit SetflParser(std::istream &pot_file);
 
   void parseHeader() override;
 

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -16,6 +16,7 @@ set(TEST_SOURCE_FILES
         container/linear_array_test.cpp
         data_structure/array_map_test.cpp
         container/atom_type_lists_test.cpp
+        parser/setfl_parser_test.cpp
         eam_alloy_pot_api_test.cpp
         interpolation_lists_sync_test.cpp
         eam_fs_pot_api_test.cpp

--- a/tests/unit/eam_pot_fixture.hpp
+++ b/tests/unit/eam_pot_fixture.hpp
@@ -84,6 +84,7 @@ public:
   constexpr static unsigned int ELE_SIZE = 3;
   constexpr static unsigned int DATA_SIZE = 5000;
   constexpr static unsigned int RAND_SEED = 27324;
+  constexpr static double DELTA = 0.001;
 
   void SetUp() override {
     const unsigned int root_rank = 0;
@@ -109,12 +110,12 @@ public:
       const int key = i; // key is atom number
       prop_key_list[i] = key;
       x0_embedded.push_back(key);
-      eam_fs_loader->embedded.append(key, DATA_SIZE, key, 0.001, data_buff_emb);
+      eam_fs_loader->embedded.append(key, DATA_SIZE, key, DELTA, data_buff_emb);
       // add electron density potential
       for (int j = 0; j < ELE_SIZE; j++) {
         const double x0_ele = -(i * ELE_SIZE + j);
         x0_electron_density.push_back(x0_ele);
-        eam_fs_loader->electron_density.append(key, DATA_SIZE, x0_ele, 0.001, data_buff_elec);
+        eam_fs_loader->electron_density.append(key, DATA_SIZE, x0_ele, DELTA, data_buff_elec);
       }
     }
 
@@ -127,7 +128,7 @@ public:
       for (j = 0; j <= i; j++) {
         const double x0 = i * ELE_SIZE + j;
         x0_eam_phi.push_back(x0);
-        eam_fs_loader->eam_phi.append(prop_key_list[i], prop_key_list[j], DATA_SIZE, x0, 0.001, data_buff);
+        eam_fs_loader->eam_phi.append(prop_key_list[i], prop_key_list[j], DATA_SIZE, x0, DELTA, data_buff);
       }
     }
 

--- a/tests/unit/eam_pot_fixture.hpp
+++ b/tests/unit/eam_pot_fixture.hpp
@@ -17,6 +17,7 @@ public:
   constexpr static unsigned int ELE_SIZE = 3;
   constexpr static unsigned int DATA_SIZE = 5000;
   constexpr static unsigned int RAND_SEED = 27321;
+  constexpr static double DELTA = 0.001;
 
   void SetUp() override {
     const unsigned int root_rank = 0;
@@ -43,8 +44,8 @@ public:
       prop_key_list[i] = key;
       x0_electron_density.push_back(key);
       x0_embedded.push_back(-key);
-      eam_alloy_loader->embedded.append(key, DATA_SIZE, -key, 0.001, data_buff_emb);
-      eam_alloy_loader->electron_density.append(key, DATA_SIZE, key, 0.001, data_buff_elec);
+      eam_alloy_loader->embedded.append(key, DATA_SIZE, -key, DELTA, data_buff_emb);
+      eam_alloy_loader->electron_density.append(key, DATA_SIZE, key, DELTA, data_buff_elec);
     }
 
     int i, j;
@@ -56,7 +57,7 @@ public:
       for (j = 0; j <= i; j++) {
         const double x0 = i * ELE_SIZE + j;
         x0_eam_phi.push_back(x0);
-        eam_alloy_loader->eam_phi.append(prop_key_list[i], prop_key_list[j], DATA_SIZE, x0, 0.001, data_buff);
+        eam_alloy_loader->eam_phi.append(prop_key_list[i], prop_key_list[j], DATA_SIZE, x0, DELTA, data_buff);
       }
     }
 

--- a/tests/unit/parser/setfl_parser_test.cpp
+++ b/tests/unit/parser/setfl_parser_test.cpp
@@ -11,7 +11,7 @@
 #include "../eam_pot_fixture.hpp"
 #include "parser/setfl_parser.h"
 
-void dump_to_buffer(const int eles_num, EamPotFileHeader header, eam *_pot, std::ostream &out) {
+void dump_to_buffer(const int eam_style, const int eles_num, EamPotFileHeader header, eam *_pot, std::ostream &out) {
   // header
   out << "#comment 1" << std::endl;
   out << "#comment 2" << std::endl;
@@ -36,14 +36,29 @@ void dump_to_buffer(const int eles_num, EamPotFileHeader header, eam *_pot, std:
     }
 
     // dump electron density
-    auto density = _pot->eam_pot_loader->loadElectronDensity(i);
-    double *dv = density->values;
-    for (int k = 0; k < density->n; k++) {
-      out << dv[k + 1];
-      if (k % 4 == 3) {
-        out << std::endl;
-      } else {
-        out << " ";
+    if (eam_style == EAM_STYLE_ALLOY) {
+      auto density = _pot->eam_pot_loader->loadElectronDensity(i);
+      double *dv = density->values;
+      for (int k = 0; k < density->n; k++) {
+        out << dv[k + 1];
+        if (k % 4 == 3) {
+          out << std::endl;
+        } else {
+          out << " ";
+        }
+      }
+    } else if (eam_style == EAM_STYLE_FS) {
+      for (int j = 0; j < eles_num; j++) {
+        auto density = _pot->eam_pot_loader->loadElectronDensity(j, i);
+        double *dv = density->values;
+        for (int k = 0; k < density->n; k++) {
+          out << dv[k + 1];
+          if (k % 4 == 3) {
+            out << std::endl;
+          } else {
+            out << " ";
+          }
+        }
       }
     }
   }
@@ -66,11 +81,11 @@ void dump_to_buffer(const int eles_num, EamPotFileHeader header, eam *_pot, std:
 
 // This test dumps fixture to a buffer and then parse from the buffer.
 // Last, it compares the data in the parser and the fixture.
-TEST_F(EamPotAlloyTestFixture, test_eam_setfl_parser) {
+TEST_F(EamPotAlloyTestFixture, test_eam_alloy_setfl_parser) {
   std::stringstream s;
   //  std::ofstream s("out.tmp.txt"); // can also dump to file.
   EamPotFileHeader header = {.nRho = DATA_SIZE, .nR = DATA_SIZE, .dRho = DELTA, .dR = DELTA, .cutoff = 0.5};
-  dump_to_buffer(ELE_SIZE, header, _pot, s);
+  dump_to_buffer(EAM_STYLE_ALLOY, ELE_SIZE, header, _pot, s);
 
   constexpr int _ELE_SIZE = ELE_SIZE;
   // new parser
@@ -132,6 +147,84 @@ TEST_F(EamPotAlloyTestFixture, test_eam_setfl_parser) {
       EXPECT_EQ(test_pair->invDx, pair->invDx);
       //      EXPECT_EQ(test_pair->x0, pair->x0);
       //      EXPECT_EQ(test_pair->max_val, pair->max_val);
+      for (int k = 0; k < pair->n; k++) {
+        EXPECT_EQ(test_pair->values[k], pair->values[k]);
+        if (test_pair->values[k] != pair->values[k]) {
+          GTEST_FAIL();
+        }
+      }
+    }
+  }
+}
+
+TEST_F(EamPotFsTestFixture, test_eam_fs_setfl_parser) {
+  std::stringstream s;
+  //  std::ofstream s("out.tmp.txt"); // can also dump to file.
+  EamPotFileHeader header = {.nRho = DATA_SIZE, .nR = DATA_SIZE, .dRho = DELTA, .dR = DELTA, .cutoff = 0.5};
+  dump_to_buffer(EAM_STYLE_FS, ELE_SIZE, header, _pot, s);
+
+  constexpr int _ELE_SIZE = ELE_SIZE;
+  // new parser
+  SetflParser *parser = new SetflParser(s);
+  // parse header
+  parser->parseHeader();
+  EXPECT_EQ(parser->getEles(), _ELE_SIZE);
+  auto test_header = parser->getHeader();
+  EXPECT_EQ(test_header.cutoff, header.cutoff);
+  EXPECT_EQ(test_header.dR, header.dR);
+  EXPECT_EQ(test_header.dRho, header.dRho);
+  EXPECT_EQ(test_header.nR, header.nR);
+  EXPECT_EQ(test_header.nRho, header.nRho);
+
+  // parse body
+  auto test_pot = eam::newInstance(EAM_STYLE_FS, parser->getEles(), 0, 0, MPI_COMM_WORLD);
+  parser->parseBody(test_pot);
+
+  // compare body
+  for (int i = 0; i < ELE_SIZE; i++) {
+    // compare embedded energy
+    auto emb = _pot->eam_pot_loader->loadEmbedded(i);
+    EXPECT_NE(test_pot->eam_pot_loader, nullptr);
+    auto test_emb = test_pot->eam_pot_loader->loadEmbedded(i);
+    EXPECT_NE(test_emb, nullptr);
+    EXPECT_EQ(test_emb->n, emb->n);
+    EXPECT_EQ(test_emb->invDx, emb->invDx);
+    // todo: x0 and max_val are generated in a different way in the fixture. we currently ignore the tests.
+    // EXPECT_EQ(test_emb->x0, emb->x0);
+    // EXPECT_EQ(test_emb->max_val, emb->max_val);
+    for (int k = 0; k < emb->n; k++) {
+      EXPECT_EQ(test_emb->values[k], emb->values[k]);
+      if (test_emb->values[k] != emb->values[k]) {
+        GTEST_FAIL();
+      }
+    }
+
+    // compare electron density
+    for (int j = 0; j < ELE_SIZE; j++) {
+      auto density = _pot->eam_pot_loader->loadElectronDensity(j, i);
+      auto test_density = test_pot->eam_pot_loader->loadElectronDensity(j, i);
+      EXPECT_EQ(test_density->n, density->n);
+      EXPECT_EQ(test_density->invDx, density->invDx);
+      // EXPECT_EQ(test_density->x0, density->x0);
+      // EXPECT_EQ(test_density->max_val, density->max_val);
+      for (int k = 0; k < density->n; k++) {
+        EXPECT_EQ(test_density->values[k], density->values[k]);
+        if (test_density->values[k] != density->values[k]) {
+          GTEST_FAIL();
+        }
+      }
+    }
+  }
+
+  // compare pair potential
+  for (int i = 0; i < ELE_SIZE; i++) {
+    for (int j = 0; j <= i; j++) {
+      auto pair = _pot->eam_pot_loader->loadEamPhi(i, j);
+      auto test_pair = test_pot->eam_pot_loader->loadEamPhi(i, j);
+      EXPECT_EQ(test_pair->n, pair->n);
+      EXPECT_EQ(test_pair->invDx, pair->invDx);
+      // EXPECT_EQ(test_pair->x0, pair->x0);
+      // EXPECT_EQ(test_pair->max_val, pair->max_val);
       for (int k = 0; k < pair->n; k++) {
         EXPECT_EQ(test_pair->values[k], pair->values[k]);
         if (test_pair->values[k] != pair->values[k]) {

--- a/tests/unit/parser/setfl_parser_test.cpp
+++ b/tests/unit/parser/setfl_parser_test.cpp
@@ -1,0 +1,143 @@
+//
+// Created by genshen on 2023/7/20.
+//
+
+#include <fstream>
+#include <sstream>
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include "../eam_pot_fixture.hpp"
+#include "parser/setfl_parser.h"
+
+void dump_to_buffer(const int eles_num, EamPotFileHeader header, eam *_pot, std::ostream &out) {
+  // header
+  out << "#comment 1" << std::endl;
+  out << "#comment 2" << std::endl;
+  out << "#comment 3" << std::endl;
+  out << eles_num << " Fe Cu Ni" << std::endl;
+  out << header.nRho << " " << header.dRho << " " << header.nR << " " << header.dR << " " << header.cutoff << std::endl;
+
+  // body
+  out.precision(17);
+  for (int i = 0; i < eles_num; i++) {
+    out << 26 << " " << 55.845 << " " << 2.85532 << " bcc" << std::endl;
+    // dump embedded energy
+    auto emb = _pot->eam_pot_loader->loadEmbedded(i);
+    double *ev = emb->values;
+    for (int k = 0; k < emb->n; k++) {
+      out << ev[k + 1];
+      if (k % 4 == 3) {
+        out << std::endl;
+      } else {
+        out << " ";
+      }
+    }
+
+    // dump electron density
+    auto density = _pot->eam_pot_loader->loadElectronDensity(i);
+    double *dv = density->values;
+    for (int k = 0; k < density->n; k++) {
+      out << dv[k + 1];
+      if (k % 4 == 3) {
+        out << std::endl;
+      } else {
+        out << " ";
+      }
+    }
+  }
+  // dump pair potential
+  for (int i = 0; i < eles_num; i++) {
+    for (int j = 0; j <= i; j++) {
+      auto pair = _pot->eam_pot_loader->loadEamPhi(i, j);
+      double *pv = pair->values;
+      for (int k = 0; k < pair->n; k++) {
+        out << pv[k + 1];
+        if (k % 4 == 3) {
+          out << std::endl;
+        } else {
+          out << " ";
+        }
+      }
+    }
+  }
+}
+
+// This test dumps fixture to a buffer and then parse from the buffer.
+// Last, it compares the data in the parser and the fixture.
+TEST_F(EamPotAlloyTestFixture, test_eam_setfl_parser) {
+  std::stringstream s;
+  //  std::ofstream s("out.tmp.txt"); // can also dump to file.
+  EamPotFileHeader header = {.nRho = DATA_SIZE, .nR = DATA_SIZE, .dRho = DELTA, .dR = DELTA, .cutoff = 0.5};
+  dump_to_buffer(ELE_SIZE, header, _pot, s);
+
+  constexpr int _ELE_SIZE = ELE_SIZE;
+  // new parser
+  SetflParser *parser = new SetflParser(s);
+  // parse header
+  parser->parseHeader();
+  EXPECT_EQ(parser->getEles(), _ELE_SIZE);
+  auto test_header = parser->getHeader();
+  EXPECT_EQ(test_header.cutoff, header.cutoff);
+  EXPECT_EQ(test_header.dR, header.dR);
+  EXPECT_EQ(test_header.dRho, header.dRho);
+  EXPECT_EQ(test_header.nR, header.nR);
+  EXPECT_EQ(test_header.nRho, header.nRho);
+
+  // parse body
+  auto test_pot = eam::newInstance(EAM_STYLE_ALLOY, parser->getEles(), 0, 0, MPI_COMM_WORLD);
+  parser->parseBody(test_pot);
+
+  // compare body
+  for (int i = 0; i < ELE_SIZE; i++) {
+    // compare embedded energy
+    auto emb = _pot->eam_pot_loader->loadEmbedded(i);
+    EXPECT_NE(test_pot->eam_pot_loader, nullptr);
+    auto test_emb = test_pot->eam_pot_loader->loadEmbedded(i);
+    EXPECT_NE(test_emb, nullptr);
+    EXPECT_EQ(test_emb->n, emb->n);
+    EXPECT_EQ(test_emb->invDx, emb->invDx);
+    // todo: x0 and max_val are generated in a different way in the fixture. we currently ignore the tests.
+    // EXPECT_EQ(test_emb->x0, emb->x0);
+    // EXPECT_EQ(test_emb->max_val, emb->max_val);
+    for (int k = 0; k < emb->n; k++) {
+      EXPECT_EQ(test_emb->values[k], emb->values[k]);
+      if (test_emb->values[k] != emb->values[k]) {
+        GTEST_FAIL();
+      }
+    }
+
+    // compare electron density
+    auto density = _pot->eam_pot_loader->loadElectronDensity(i);
+    auto test_density = test_pot->eam_pot_loader->loadElectronDensity(i);
+    EXPECT_EQ(test_density->n, density->n);
+    EXPECT_EQ(test_density->invDx, density->invDx);
+    //    EXPECT_EQ(test_density->x0, density->x0);
+    //    EXPECT_EQ(test_density->max_val, density->max_val);
+    for (int k = 0; k < density->n; k++) {
+      EXPECT_EQ(test_density->values[k], density->values[k]);
+      if (test_density->values[k] != density->values[k]) {
+        GTEST_FAIL();
+      }
+    }
+  }
+
+  // compare pair potential
+  for (int i = 0; i < ELE_SIZE; i++) {
+    for (int j = 0; j <= i; j++) {
+      auto pair = _pot->eam_pot_loader->loadEamPhi(i, j);
+      auto test_pair = test_pot->eam_pot_loader->loadEamPhi(i, j);
+      EXPECT_EQ(test_pair->n, pair->n);
+      EXPECT_EQ(test_pair->invDx, pair->invDx);
+      //      EXPECT_EQ(test_pair->x0, pair->x0);
+      //      EXPECT_EQ(test_pair->max_val, pair->max_val);
+      for (int k = 0; k < pair->n; k++) {
+        EXPECT_EQ(test_pair->values[k], pair->values[k]);
+        if (test_pair->values[k] != pair->values[k]) {
+          GTEST_FAIL();
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
The potential file parameter C-Style `FILE *` in potential parser api is replaced by C++ iostream.

By using C++ iostream, we can create more elegant unit tests for potential parser,
because we can write generated potential data to a stringstream and then parse from the stringstream
(If we use the  C-Style `FILE *` api, we need first write data into filesystem and read/parse from a file).