### PR TITLE
Test parser api `setFilterEleTypes` and fix a bug of element filtering in eam/fs parsing

### DIFF
--- a/src/parser/setfl_parser.cpp
+++ b/src/parser/setfl_parser.cpp
@@ -145,7 +145,7 @@ void SetflParser::parseBodyEamFs(EamFsLoader *pot_loader) {
     for (int j = 0; j < file_ele_size; j++) {
       grab(pot_file, header.nR, buf);
       atom_type::_type_prop_key key2 = j;
-      if (!isEleTypesFilterEnabled() || (isInFilterList(key) && isInFilterList(key))) {
+      if (!isEleTypesFilterEnabled() || (isInFilterList(key) && isInFilterList(key2))) {
         pot_loader->electron_density.push_back(header.nR, x0, header.dR, buf);
       }
     }

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -16,6 +16,7 @@ set(TEST_SOURCE_FILES
         container/linear_array_test.cpp
         data_structure/array_map_test.cpp
         container/atom_type_lists_test.cpp
+        parser/api_setFilterEleTypes_test.cpp
         parser/setfl_parser_test.cpp
         eam_alloy_pot_api_test.cpp
         interpolation_lists_sync_test.cpp

--- a/tests/unit/eam_pot_fixture.hpp
+++ b/tests/unit/eam_pot_fixture.hpp
@@ -30,31 +30,30 @@ public:
     std::mt19937 rng(RAND_SEED);
     std::uniform_real_distribution<double> dist_f(0.0, 5.0);
 
-    // data buffer
-    double data_buff_emb[5000] = {};
-    double data_buff_elec[5000] = {};
-    for (int k = 0; k < 5000; k++) {
-      data_buff_emb[k] = k * dist_f(rng);
-      data_buff_elec[k] = k * dist_f(rng);
-    }
-
     auto eam_alloy_loader = dynamic_cast<EamAlloyLoader *>(_pot->eam_pot_loader);
     for (int i = 0; i < ELE_SIZE; i++) {
       const int key = i; // key is atom number
       prop_key_list[i] = key;
       x0_electron_density.push_back(key);
       x0_embedded.push_back(-key);
+      // data buffer
+      double data_buff_emb[5000] = {};
+      double data_buff_elec[5000] = {};
+      for (int k = 0; k < 5000; k++) {
+        data_buff_emb[k] = k * dist_f(rng);
+        data_buff_elec[k] = k * dist_f(rng);
+      }
       eam_alloy_loader->embedded.append(key, DATA_SIZE, -key, DELTA, data_buff_emb);
       eam_alloy_loader->electron_density.append(key, DATA_SIZE, key, DELTA, data_buff_elec);
     }
 
     int i, j;
     for (i = 0; i < ELE_SIZE; i++) {
-      double data_buff[5000] = {};
-      for (int k = 0; k < 5000; k++) {
-        data_buff[k] = k * dist_f(rng);
-      }
       for (j = 0; j <= i; j++) {
+        double data_buff[5000] = {};
+        for (int k = 0; k < 5000; k++) {
+          data_buff[k] = k * dist_f(rng);
+        }
         const double x0 = i * ELE_SIZE + j;
         x0_eam_phi.push_back(x0);
         eam_alloy_loader->eam_phi.append(prop_key_list[i], prop_key_list[j], DATA_SIZE, x0, DELTA, data_buff);
@@ -97,37 +96,42 @@ public:
     std::mt19937 rng(RAND_SEED);
     std::uniform_real_distribution<double> dist_f(0.0, 5.0);
 
-    // data buffer
-    double data_buff_emb[5000] = {};
-    double data_buff_elec[5000] = {};
-    for (int k = 0; k < 5000; k++) {
-      data_buff_emb[k] = k * dist_f(rng);
-      data_buff_elec[k] = k * dist_f(rng);
-    }
-
     auto eam_fs_loader = dynamic_cast<EamFsLoader *>(_pot->eam_pot_loader);
     for (int i = 0; i < ELE_SIZE; i++) {
       const int key = i; // key is atom number
       prop_key_list[i] = key;
       x0_embedded.push_back(key);
+
+      // data buffer
+      double data_buff_emb[5000] = {};
+      for (int k = 0; k < 5000; k++) {
+        data_buff_emb[k] = k * dist_f(rng);
+      }
       eam_fs_loader->embedded.append(key, DATA_SIZE, key, DELTA, data_buff_emb);
+
       // add electron density potential
       for (int j = 0; j < ELE_SIZE; j++) {
         const double x0_ele = -(i * ELE_SIZE + j);
         x0_electron_density.push_back(x0_ele);
+
+        double data_buff_elec[5000] = {};
+        for (int k = 0; k < 5000; k++) {
+          data_buff_emb[k] = k * dist_f(rng);
+          data_buff_elec[k] = k * dist_f(rng);
+        }
         eam_fs_loader->electron_density.append(key, DATA_SIZE, x0_ele, DELTA, data_buff_elec);
       }
     }
 
     int i, j;
     for (i = 0; i < ELE_SIZE; i++) {
-      double data_buff[5000] = {};
-      for (int k = 0; k < 5000; k++) {
-        data_buff[k] = k * dist_f(rng);
-      }
       for (j = 0; j <= i; j++) {
         const double x0 = i * ELE_SIZE + j;
         x0_eam_phi.push_back(x0);
+        double data_buff[5000] = {};
+        for (int k = 0; k < 5000; k++) {
+          data_buff[k] = k * dist_f(rng);
+        }
         eam_fs_loader->eam_phi.append(prop_key_list[i], prop_key_list[j], DATA_SIZE, x0, DELTA, data_buff);
       }
     }

--- a/tests/unit/parser/api_setFilterEleTypes_test.cpp
+++ b/tests/unit/parser/api_setFilterEleTypes_test.cpp
@@ -1,0 +1,91 @@
+//
+// Created by genshen on 2023/7/24.
+//
+
+#include <fstream>
+#include <sstream>
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include "../eam_pot_fixture.hpp"
+#include "parser/setfl_parser.h"
+
+void dump_to_buffer(const int eam_style, const int eles_num, EamPotFileHeader header, eam *_pot, std::ostream &out);
+
+#define DO_TABLE_COMPARE(STD_API, TEST_API)                                                                            \
+  {                                                                                                                    \
+    auto tab = STD_API;                                                                                                \
+    auto test_tab = TEST_API;                                                                                          \
+    for (int k = 0; k < tab->n; k++) {                                                                                 \
+      EXPECT_EQ(test_tab->values[k], tab->values[k]);                                                                  \
+    }                                                                                                                  \
+  }
+
+TEST_F(EamPotAlloyTestFixture, test_eam_alloy_parser_setFilterEleTypes) {
+  std::stringstream s;
+  //  std::ofstream s("out.tmp.txt"); // can also dump to file.
+  EamPotFileHeader header = {.nRho = DATA_SIZE, .nR = DATA_SIZE, .dRho = DELTA, .dR = DELTA, .cutoff = 0.5};
+  dump_to_buffer(EAM_STYLE_ALLOY, ELE_SIZE, header, _pot, s);
+
+  // new parser
+  SetflParser *parser = new SetflParser(s);
+  parser->setFilterEleTypes({0, 2});
+
+  // parse header
+  parser->parseHeader();
+  EXPECT_EQ(parser->getEles(), 2);
+  parser->getHeader();
+
+  // parse body
+  auto test_pot = eam::newInstance(EAM_STYLE_ALLOY, parser->getEles(), 0, 0, MPI_COMM_WORLD);
+  parser->parseBody(test_pot);
+
+  // do assert
+  DO_TABLE_COMPARE(_pot->eam_pot_loader->loadEmbedded(0), test_pot->eam_pot_loader->loadEmbedded(0));
+  DO_TABLE_COMPARE(_pot->eam_pot_loader->loadEmbedded(2), test_pot->eam_pot_loader->loadEmbedded(1));
+
+  DO_TABLE_COMPARE(_pot->eam_pot_loader->loadElectronDensity(0), test_pot->eam_pot_loader->loadElectronDensity(0));
+  DO_TABLE_COMPARE(_pot->eam_pot_loader->loadElectronDensity(2), test_pot->eam_pot_loader->loadElectronDensity(1));
+
+  DO_TABLE_COMPARE(_pot->eam_pot_loader->loadEamPhi(0, 0), test_pot->eam_pot_loader->loadEamPhi(0, 0));
+  DO_TABLE_COMPARE(_pot->eam_pot_loader->loadEamPhi(0, 2), test_pot->eam_pot_loader->loadEamPhi(0, 1));
+  DO_TABLE_COMPARE(_pot->eam_pot_loader->loadEamPhi(2, 2), test_pot->eam_pot_loader->loadEamPhi(1, 1));
+  DO_TABLE_COMPARE(_pot->eam_pot_loader->loadEamPhi(2, 0), test_pot->eam_pot_loader->loadEamPhi(1, 0));
+}
+
+TEST_F(EamPotFsTestFixture, test_eam_fs_parser_setFilterEleTypes) {
+  std::stringstream s;
+  //  std::ofstream s("out.tmp.txt"); // can also dump to file.
+  EamPotFileHeader header = {.nRho = DATA_SIZE, .nR = DATA_SIZE, .dRho = DELTA, .dR = DELTA, .cutoff = 0.5};
+  dump_to_buffer(EAM_STYLE_FS, ELE_SIZE, header, _pot, s);
+
+  // new parser
+  SetflParser *parser = new SetflParser(s);
+  parser->setFilterEleTypes({1, 2});
+
+  // parse header
+  parser->parseHeader();
+  EXPECT_EQ(parser->getEles(), 2);
+  parser->getHeader();
+
+  // parse body
+  auto test_pot = eam::newInstance(EAM_STYLE_FS, parser->getEles(), 0, 0, MPI_COMM_WORLD);
+  parser->parseBody(test_pot);
+
+  // do assert
+  DO_TABLE_COMPARE(_pot->eam_pot_loader->loadEmbedded(1), test_pot->eam_pot_loader->loadEmbedded(0));
+  DO_TABLE_COMPARE(_pot->eam_pot_loader->loadEmbedded(2), test_pot->eam_pot_loader->loadEmbedded(1));
+
+  DO_TABLE_COMPARE(_pot->eam_pot_loader->loadElectronDensity(1, 2),
+                   test_pot->eam_pot_loader->loadElectronDensity(0, 1));
+  DO_TABLE_COMPARE(_pot->eam_pot_loader->loadElectronDensity(2, 2),
+                   test_pot->eam_pot_loader->loadElectronDensity(1, 1));
+  DO_TABLE_COMPARE(_pot->eam_pot_loader->loadElectronDensity(2, 1),
+                   test_pot->eam_pot_loader->loadElectronDensity(1, 0));
+
+  DO_TABLE_COMPARE(_pot->eam_pot_loader->loadEamPhi(1, 1), test_pot->eam_pot_loader->loadEamPhi(0, 0));
+  DO_TABLE_COMPARE(_pot->eam_pot_loader->loadEamPhi(1, 2), test_pot->eam_pot_loader->loadEamPhi(0, 1));
+  DO_TABLE_COMPARE(_pot->eam_pot_loader->loadEamPhi(2, 2), test_pot->eam_pot_loader->loadEamPhi(1, 1));
+  DO_TABLE_COMPARE(_pot->eam_pot_loader->loadEamPhi(2, 1), test_pot->eam_pot_loader->loadEamPhi(1, 0));
+}


### PR DESCRIPTION
Description of the bug fixing:  
In eam/fs electron charge density parsing, due to a code typo, we did not check the existence of the
second element. This may add additional potential table to the potential table list, which may lead
to wrong offset index in potential loading. This PR/MR fixed this bug.