### PR TITLE
Refactor(eam): add template parameter `EAM_STYLE` to eam apis for selecting fs or alloy style

### DIFF
--- a/src/container/interpolation_object.cpp
+++ b/src/container/interpolation_object.cpp
@@ -33,12 +33,14 @@ void InterpolationObject::bcastInterpolationObject(const int root, const int ran
     int n;
     double x0;
     double inv_dx;
+    double max_val;
   } interpolation_data_pack;
   interpolation_data_pack temp;
   if (rank == root) {
     temp.n = this->n;
     temp.x0 = this->x0;
     temp.inv_dx = this->invDx;
+    temp.max_val = max_val;
   }
 
   MPI_Bcast(&temp, sizeof(interpolation_data_pack), MPI_BYTE, root, comm);
@@ -47,6 +49,7 @@ void InterpolationObject::bcastInterpolationObject(const int root, const int ran
     this->n = temp.n;
     this->x0 = temp.x0;
     this->invDx = temp.inv_dx;
+    this->max_val = temp.max_val;
     values = new double[n + 1];
   }
 

--- a/src/eam.cpp
+++ b/src/eam.cpp
@@ -19,8 +19,10 @@ eam *eam::newInstance(const int eam_style, atom_type::_type_atom_types n_ele_roo
 eam::eam(const atom_type::_type_atom_types n_ele, const int eam_style) : _n_eles(n_ele), eam_style(eam_style) {
   if (eam_style == EAM_STYLE_ALLOY) {
     eam_pot_loader = new EamAlloyLoader(n_ele);
+    alloy_loader = dynamic_cast<EamAlloyLoader *>(eam_pot_loader);
   } else if (eam_style == EAM_STYLE_FS) {
     eam_pot_loader = new EamFsLoader(n_ele);
+    fs_loader = dynamic_cast<EamFsLoader *>(eam_pot_loader);
   } else {
     printf("The eam style `%d` is not implemented\n", eam_style);
   }
@@ -40,14 +42,25 @@ eam::~eam() {
 
 void eam::setlatticeType(char *_latticeType) { strcpy(latticeType, _latticeType); }
 
+template <int EAM_STYLE>
 double eam::toForce(const atom_type::_type_prop_key key_from, const atom_type::_type_prop_key key_to,
                     const double dist2, const double df_from, const double df_to) {
   double fpair;
   double phi, phip, psip, z2, z2p;
 
-  const InterpolationObject *phi_spline = eam_pot_loader->loadEamPhi(key_from, key_to);
-  const InterpolationObject *electron_spline_from = ele_charge_load_wrapper(key_from, key_to);
-  const InterpolationObject *electron_spline_to = ele_charge_load_wrapper(key_to, key_from);
+  InterpolationObject *phi_spline = nullptr;
+  InterpolationObject *electron_spline_from = nullptr;
+  InterpolationObject *electron_spline_to = nullptr;
+
+  if (EAM_STYLE == EAM_STYLE_ALLOY) {
+    phi_spline = (alloy_loader)->loadEamPhi(key_from, key_to);
+    electron_spline_from = alloy_loader->loadElectronDensity(key_from);
+    electron_spline_to = alloy_loader->loadElectronDensity(key_to);
+  } else if (EAM_STYLE == EAM_STYLE_FS) {
+    phi_spline = (fs_loader)->loadEamPhi(key_from, key_to);
+    electron_spline_from = fs_loader->loadElectronDensity(key_from, key_to);
+    electron_spline_to = fs_loader->loadElectronDensity(key_to, key_from);
+  }
 
   const double r = sqrt(dist2);
   const SplineData phi_s = phi_spline->findSpline(r);
@@ -73,8 +86,16 @@ double eam::toForce(const atom_type::_type_prop_key key_from, const atom_type::_
   return fpair;
 }
 
+template <int EAM_STYLE>
 double eam::chargeDensity(const atom_type::_type_prop_key _atom_key, const double dist2) const {
-  const InterpolationObject *electron_spline = eam_pot_loader->loadElectronDensity(_atom_key);
+  InterpolationObject *electron_spline = nullptr;
+  if (EAM_STYLE == EAM_STYLE_ALLOY) {
+    electron_spline = alloy_loader->loadElectronDensity(_atom_key);
+  } else if (EAM_STYLE == EAM_STYLE_FS) {
+    electron_spline = fs_loader->loadElectronDensity(_atom_key);
+  }
+
+  //  const InterpolationObject *electron_spline = eam_pot_loader->loadElectronDensity(_atom_key);
   const double r = sqrt(dist2);
   const SplineData s = electron_spline->findSpline(r);
   return ((s.spline[3] * s.p + s.spline[4]) * s.p + s.spline[5]) * s.p + s.spline[6];
@@ -115,12 +136,31 @@ double eam::embedEnergyImp(const InterpolationObject *embed, const double rho, c
   return phi;
 }
 
+template <int EAM_STYLE>
 double eam::pairPotential(const atom_type::_type_prop_key key_from, const atom_type::_type_prop_key key_to,
                           const double dist2) const {
   const InterpolationObject *phi_spline = eam_pot_loader->loadEamPhi(key_from, key_to);
   const double r = sqrt(dist2);
-
   const SplineData s = phi_spline->findSpline(r);
   const double phi_r = ((s.spline[3] * s.p + s.spline[4]) * s.p + s.spline[5]) * s.p + s.spline[6]; // pair_pot * r
   return phi_r / r;
 }
+
+template double eam::toForce<EAM_STYLE_ALLOY>(const atom_type::_type_prop_key key_from,
+                                              const atom_type::_type_prop_key key_to, const double dist2,
+                                              const double df_from, const double df_to);
+
+template double eam::toForce<EAM_STYLE_FS>(const atom_type::_type_prop_key key_from,
+                                           const atom_type::_type_prop_key key_to, const double dist2,
+                                           const double df_from, const double df_to);
+
+template double eam::chargeDensity<EAM_STYLE_ALLOY>(const atom_type::_type_prop_key _atom_key,
+                                                    const double dist2) const;
+
+template double eam::chargeDensity<EAM_STYLE_FS>(const atom_type::_type_prop_key _atom_key, const double dist2) const;
+
+template double eam::pairPotential<EAM_STYLE_ALLOY>(const atom_type::_type_prop_key key_from,
+                                                    const atom_type::_type_prop_key key_to, const double dist2) const;
+
+template double eam::pairPotential<EAM_STYLE_FS>(const atom_type::_type_prop_key key_from,
+                                                 const atom_type::_type_prop_key key_to, const double dist2) const;

--- a/src/eam.h
+++ b/src/eam.h
@@ -62,6 +62,7 @@ public:
 
   /**
    * Calculate force of two atoms.
+   * @tparam EAM_STYLE the eam style can be EAM_STYLE_ALLOY or EAM_STYLE_FS.
    * @param key_from type of the center atom
    * @param key_to type of the neighbor atom
    * @param dist2 distance^2 of the two atoms.
@@ -69,6 +70,7 @@ public:
    * @param df_to df of the neighbor atom
    * @return the force of the two atoms.
    */
+  template <int EAM_STYLE>
   double toForce(const atom_type::_type_prop_key key_from, const atom_type::_type_prop_key key_to, const double dist2,
                  const double df_from, const double df_to);
 
@@ -79,6 +81,7 @@ public:
    * @param dist2 the square of the distance between atom i and atom j.
    * @return the contribution to electron charge density from atom j.
    */
+  template <int EAM_STYLE = EAM_STYLE_ALLOY>
   double chargeDensity(const atom_type::_type_prop_key _atom_key, const double dist2) const;
 
   /**
@@ -116,8 +119,10 @@ public:
 
   /**
    * pair potential energy.
+   * @tparam EAM_STYLE the eam style can be EAM_STYLE_ALLOY or EAM_STYLE_FS.
    * @return pair potential energy.
    */
+  template <int EAM_STYLE>
   double pairPotential(const atom_type::_type_prop_key key_from, const atom_type::_type_prop_key key_to,
                        const double dist2) const;
 
@@ -134,11 +139,12 @@ public:
   inline atom_type::_type_atom_types geEles() const { return _n_eles; }
 
 private:
+  template <int EAM_STYLE>
   inline InterpolationObject *ele_charge_load_wrapper(const atom_type::_type_prop_key _atom_key_me,
                                                       const atom_type::_type_prop_key _atom_key_nei) {
-    if (eam_style == EAM_STYLE_ALLOY) {
+    if (EAM_STYLE == EAM_STYLE_ALLOY) {
       return eam_pot_loader->loadElectronDensity(_atom_key_me);
-    } else if (eam_style == EAM_STYLE_FS) {
+    } else if (EAM_STYLE == EAM_STYLE_FS) {
       return eam_pot_loader->loadElectronDensity(_atom_key_me, _atom_key_nei);
     } else {
       printf("error: unspecified eam style.\n");
@@ -153,6 +159,9 @@ public:
    * different eam potential style: eam/alloy, eam/fs.
    */
   EamPotTableLoaderApi *eam_pot_loader;
+
+  EamAlloyLoader *alloy_loader = nullptr;
+  EamFsLoader *fs_loader = nullptr;
 
 private:
   const atom_type::_type_atom_types _n_eles; // the count of element types, which is initialized as 0.

--- a/src/eam_c_api.cpp
+++ b/src/eam_c_api.cpp
@@ -2,11 +2,11 @@
 // Created by genshen on 2023/12/21.
 //
 
-#include <eam.h>
 #include <fstream>
 #include <iostream>
 #include <string>
 
+#include "eam.h"
 #include "eam_c_api.h"
 #include "parser/setfl_parser.h"
 
@@ -66,12 +66,12 @@ double eam_pot_embed_energy(const tp_pot_atom_type _atom_key, const double rho) 
 }
 
 double eam_pot_pair_potential(const tp_pot_atom_type key_from, const tp_pot_atom_type key_to, const double dist2) {
-  return _pot->pairPotential(key_from, key_to, dist2);
+  return _pot->pairPotential<EAM_STYLE_ALLOY>(key_from, key_to, dist2);
 }
 
 double eam_pot_to_force(const tp_pot_atom_type key_from, const tp_pot_atom_type key_to, const double dist2,
                         const double df_from, const double df_to) {
-  return _pot->toForce(key_from, key_to, dist2, df_from, df_to);
+  return _pot->toForce<EAM_STYLE_ALLOY>(key_from, key_to, dist2, df_from, df_to);
 }
 
 tp_pot_atom_types_num eam_pot_get_n_eles() { return _pot->geEles(); }

--- a/tests/unit/eam_alloy_pot_api_test.cpp
+++ b/tests/unit/eam_alloy_pot_api_test.cpp
@@ -69,15 +69,15 @@ TEST_F(EamPotAlloyLinearTestFixture, test_eam_alloy_pair_phi_calc) {
     constexpr int key1 = 0;
     constexpr int key2 = 0;
     const double max_x = max_x_for_pair_phi(key1, key2);
-    EXPECT_DOUBLE_EQ(_pot->pairPotential(key1, key2, (max_x / 5.0) * (max_x / 5.0)),
+    EXPECT_DOUBLE_EQ(_pot->pairPotential<EAM_STYLE_ALLOY>(key1, key2, (max_x / 5.0) * (max_x / 5.0)),
                      expected_phi(max_x / 5.0, key1, key2));
-    EXPECT_DOUBLE_EQ(_pot->pairPotential(key1, key2, (max_x / 16.0) * (max_x / 16.0)),
+    EXPECT_DOUBLE_EQ(_pot->pairPotential<EAM_STYLE_ALLOY>(key1, key2, (max_x / 16.0) * (max_x / 16.0)),
                      expected_phi(max_x / 16.0, key1, key2));
-    EXPECT_DOUBLE_EQ(_pot->pairPotential(key1, key2, (max_x / 32.0) * (max_x / 32.0)),
+    EXPECT_DOUBLE_EQ(_pot->pairPotential<EAM_STYLE_ALLOY>(key1, key2, (max_x / 32.0) * (max_x / 32.0)),
                      expected_phi(max_x / 32.0, key1, key2));
-    EXPECT_DOUBLE_EQ(_pot->pairPotential(key1, key2, (max_x / 2.0) * (max_x / 2.0)),
+    EXPECT_DOUBLE_EQ(_pot->pairPotential<EAM_STYLE_ALLOY>(key1, key2, (max_x / 2.0) * (max_x / 2.0)),
                      expected_phi(max_x / 2.0, key1, key2));
-    EXPECT_DOUBLE_EQ(_pot->pairPotential(key1, key2, (2.0 * max_x / 3.0 * (2.0 * max_x / 3.0))),
+    EXPECT_DOUBLE_EQ(_pot->pairPotential<EAM_STYLE_ALLOY>(key1, key2, (2.0 * max_x / 3.0) * (2.0 * max_x / 3.0)),
                      expected_phi(2.0 * max_x / 3.0, key1, key2));
   }
 
@@ -86,15 +86,15 @@ TEST_F(EamPotAlloyLinearTestFixture, test_eam_alloy_pair_phi_calc) {
     constexpr int key1 = 1;
     constexpr int key2 = 2;
     const double max_x = max_x_for_pair_phi(key1, key2);
-    EXPECT_DOUBLE_EQ(_pot->pairPotential(key1, key2, (max_x / 5.0) * (max_x / 5.0)),
+    EXPECT_DOUBLE_EQ(_pot->pairPotential<EAM_STYLE_ALLOY>(key1, key2, (max_x / 5.0) * (max_x / 5.0)),
                      expected_phi(max_x / 5.0, key1, key2));
-    EXPECT_DOUBLE_EQ(_pot->pairPotential(key1, key2, (max_x / 16.0) * (max_x / 16.0)),
+    EXPECT_DOUBLE_EQ(_pot->pairPotential<EAM_STYLE_ALLOY>(key1, key2, (max_x / 16.0) * (max_x / 16.0)),
                      expected_phi(max_x / 16.0, key1, key2));
-    EXPECT_DOUBLE_EQ(_pot->pairPotential(key1, key2, (max_x / 32.0) * (max_x / 32.0)),
+    EXPECT_DOUBLE_EQ(_pot->pairPotential<EAM_STYLE_ALLOY>(key1, key2, (max_x / 32.0) * (max_x / 32.0)),
                      expected_phi(max_x / 32.0, key1, key2));
-    EXPECT_DOUBLE_EQ(_pot->pairPotential(key1, key2, (max_x / 2.0) * (max_x / 2.0)),
+    EXPECT_DOUBLE_EQ(_pot->pairPotential<EAM_STYLE_ALLOY>(key1, key2, (max_x / 2.0) * (max_x / 2.0)),
                      expected_phi(max_x / 2.0, key1, key2));
-    EXPECT_DOUBLE_EQ(_pot->pairPotential(key1, key2, (2.0 * max_x / 3.0 * (2.0 * max_x / 3.0))),
+    EXPECT_DOUBLE_EQ(_pot->pairPotential<EAM_STYLE_ALLOY>(key1, key2, (2.0 * max_x / 3.0) * (2.0 * max_x / 3.0)),
                      expected_phi(2.0 * max_x / 3.0, key1, key2));
   }
 }

--- a/tests/unit/eam_fs_pot_api_test.cpp
+++ b/tests/unit/eam_fs_pot_api_test.cpp
@@ -72,15 +72,15 @@ TEST_F(EamPotFsLinearTestFixture, test_eam_fs_pair_phi_calc) {
     constexpr int key1 = 0;
     constexpr int key2 = 0;
     const double max_x = max_x_for_pair_phi(key1, key2);
-    EXPECT_DOUBLE_EQ(_pot->pairPotential(key1, key2, (max_x / 5.0) * (max_x / 5.0)),
+    EXPECT_DOUBLE_EQ(_pot->pairPotential<EAM_STYLE_FS>(key1, key2, (max_x / 5.0) * (max_x / 5.0)),
                      expected_phi(max_x / 5.0, key1, key2));
-    EXPECT_DOUBLE_EQ(_pot->pairPotential(key1, key2, (max_x / 16.0) * (max_x / 16.0)),
+    EXPECT_DOUBLE_EQ(_pot->pairPotential<EAM_STYLE_FS>(key1, key2, (max_x / 16.0) * (max_x / 16.0)),
                      expected_phi(max_x / 16.0, key1, key2));
-    EXPECT_DOUBLE_EQ(_pot->pairPotential(key1, key2, (max_x / 32.0) * (max_x / 32.0)),
+    EXPECT_DOUBLE_EQ(_pot->pairPotential<EAM_STYLE_FS>(key1, key2, (max_x / 32.0) * (max_x / 32.0)),
                      expected_phi(max_x / 32.0, key1, key2));
-    EXPECT_DOUBLE_EQ(_pot->pairPotential(key1, key2, (max_x / 2.0) * (max_x / 2.0)),
+    EXPECT_DOUBLE_EQ(_pot->pairPotential<EAM_STYLE_FS>(key1, key2, (max_x / 2.0) * (max_x / 2.0)),
                      expected_phi(max_x / 2.0, key1, key2));
-    EXPECT_DOUBLE_EQ(_pot->pairPotential(key1, key2, (2.0 * max_x / 3.0) * (2.0 * max_x / 3.0)),
+    EXPECT_DOUBLE_EQ(_pot->pairPotential<EAM_STYLE_FS>(key1, key2, (2.0 * max_x / 3.0) * (2.0 * max_x / 3.0)),
                      expected_phi(2.0 * max_x / 3.0, key1, key2));
   }
 
@@ -89,15 +89,15 @@ TEST_F(EamPotFsLinearTestFixture, test_eam_fs_pair_phi_calc) {
     constexpr int key1 = 1;
     constexpr int key2 = 2;
     const double max_x = max_x_for_pair_phi(key1, key2);
-    EXPECT_DOUBLE_EQ(_pot->pairPotential(key1, key2, (max_x / 5.0) * (max_x / 5.0)),
+    EXPECT_DOUBLE_EQ(_pot->pairPotential<EAM_STYLE_FS>(key1, key2, (max_x / 5.0) * (max_x / 5.0)),
                      expected_phi(max_x / 5.0, key1, key2));
-    EXPECT_DOUBLE_EQ(_pot->pairPotential(key1, key2, (max_x / 16.0) * (max_x / 16.0)),
+    EXPECT_DOUBLE_EQ(_pot->pairPotential<EAM_STYLE_FS>(key1, key2, (max_x / 16.0) * (max_x / 16.0)),
                      expected_phi(max_x / 16.0, key1, key2));
-    EXPECT_DOUBLE_EQ(_pot->pairPotential(key1, key2, (max_x / 32.0) * (max_x / 32.0)),
+    EXPECT_DOUBLE_EQ(_pot->pairPotential<EAM_STYLE_FS>(key1, key2, (max_x / 32.0) * (max_x / 32.0)),
                      expected_phi(max_x / 32.0, key1, key2));
-    EXPECT_DOUBLE_EQ(_pot->pairPotential(key1, key2, (max_x / 2.0) * (max_x / 2.0)),
+    EXPECT_DOUBLE_EQ(_pot->pairPotential<EAM_STYLE_FS>(key1, key2, (max_x / 2.0) * (max_x / 2.0)),
                      expected_phi(max_x / 2.0, key1, key2));
-    EXPECT_DOUBLE_EQ(_pot->pairPotential(key1, key2, (2.0 * max_x / 3.0) * (2.0 * max_x / 3.0)),
+    EXPECT_DOUBLE_EQ(_pot->pairPotential<EAM_STYLE_FS>(key1, key2, (2.0 * max_x / 3.0) * (2.0 * max_x / 3.0)),
                      expected_phi(2.0 * max_x / 3.0, key1, key2));
   }
 }


### PR DESCRIPTION
change eam api from `pairPotential(...)` to `pairPotential<EAM_STYLE>(...)`.
Before this commit, the potential style is selected in runtime. By add the template support,
the potential can be selected in compiling time.