### PR TITLE
Feature: Update CMake mini version to 3.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.10)
 include(config.cmake)
 
 project(potential)


### PR DESCRIPTION
In cmake 4.0, compatibility with versions of CMake older than 3.5 is removed (see https://cmake.org/cmake/help/v4.0/command/cmake_minimum_required.html).